### PR TITLE
feat: enrich property streams + add audit logs (NEKT-2749, NEKT-2750)

### DIFF
--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -343,6 +343,10 @@ class PropertyTicketStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -411,6 +415,9 @@ class PropertyDealStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
         Property("calculationFormula", StringType),
     ).to_dict()
 
@@ -480,6 +487,10 @@ class PropertyContactStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -548,6 +559,10 @@ class PropertyCompanyStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -616,6 +631,10 @@ class PropertyProductStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -684,6 +703,10 @@ class PropertyLineItemStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -752,6 +775,10 @@ class PropertyEmailStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -820,6 +847,10 @@ class PropertyPostalMailStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -888,6 +919,10 @@ class PropertyCallStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -956,6 +991,10 @@ class PropertyMeetingStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -1024,6 +1063,10 @@ class PropertyTaskStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -1092,6 +1135,10 @@ class PropertyCommunicationStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property
@@ -1160,6 +1207,10 @@ class PropertyNotesStream(HubspotStream):
         ),
         Property("formField", BooleanType),
         Property("hubspot_object", StringType),
+        Property("createdUserId", StringType),
+        Property("updatedUserId", StringType),
+        Property("referencedObjectType", StringType),
+        Property("calculationFormula", StringType),
     ).to_dict()
 
     @property

--- a/tap_hubspot/streams.py
+++ b/tap_hubspot/streams.py
@@ -1832,3 +1832,48 @@ class TaskStream(DynamicIncrementalHubspotStream):
         Returns an updated path which includes the api version
         """
         return "https://api.hubapi.com/crm/v3"
+
+
+class AuditLogsStream(HubspotStream):
+    """
+    https://developers.hubspot.com/docs/api-reference/account-audit-logs-v3/guide
+
+    Extracts audit log entries from the HubSpot Account Activity API.
+    Tracks user actions such as CRM object creation, property updates,
+    security activity, and more.
+
+    Requires 'account-info.security.read' scope (Enterprise accounts only).
+    """
+
+    name = "audit_logs"
+    path = "/activity/audit-logs"
+    primary_keys = ["id"]
+    replication_key = "occurredAt"
+    records_jsonpath = "$[results][*]"
+
+    schema = PropertiesList(
+        Property("id", StringType),
+        Property("category", StringType),
+        Property("subCategory", StringType),
+        Property("action", StringType),
+        Property("targetObjectId", StringType),
+        Property("occurredAt", DateTimeType),
+        Property(
+            "actingUser",
+            ObjectType(
+                Property("userId", StringType),
+                Property("userEmail", StringType),
+            ),
+        ),
+    ).to_dict()
+
+    @property
+    def url_base(self) -> str:
+        return "https://api.hubapi.com/account-info/v3"
+
+    def get_url_params(self, context, next_page_token):
+        params = super().get_url_params(context, next_page_token)
+        starting_value = self.get_starting_replication_key_value(context)
+        if starting_value:
+            params["occurredAfter"] = starting_value
+        return params

--- a/tap_hubspot/tap.py
+++ b/tap_hubspot/tap.py
@@ -78,6 +78,7 @@ class TapHubspot(Tap):
             streams.NoteStream(self),
             streams.PostalMailStream(self),
             streams.TaskStream(self),
+            streams.AuditLogsStream(self),
         ]
 
 


### PR DESCRIPTION
Closes NEKT-2749, NEKT-2750

## Changes

### NEKT-2749 — Enrich property streams
Added the following fields to **all 13 property stream classes** (PropertyTicketStream, PropertyDealStream, PropertyContactStream, PropertyCompanyStream, PropertyProductStream, PropertyLineItemStream, PropertyEmailStream, PropertyPostalMailStream, PropertyCallStream, PropertyMeetingStream, PropertyTaskStream, PropertyCommunicationStream, PropertyNotesStream):

- `createdUserId` (StringType) — ID of the user who created the property
- `updatedUserId` (StringType) — ID of the user who last updated the property
- `referencedObjectType` (StringType) — Object type referenced by this property (e.g. OWNER)
- `calculationFormula` (StringType) — Formula used for calculated/rollup properties (was only in PropertyDealStream, now in all)

These fields enable identifying who created each property, what object types are referenced, and whether properties are calculated/rollup/synced.

### NEKT-2750 — Audit logs stream
Added new `AuditLogsStream` class that extracts audit log entries from the HubSpot Account Activity API (`/account-info/v3/activity/audit-logs`).

Schema fields:
- `id`, `category`, `subCategory`, `action`, `targetObjectId`, `occurredAt`
- `actingUser` (object with `userId`, `userEmail`)

Supports incremental sync via `occurredAt` replication key with `occurredAfter` filter.

**Note:** Requires `account-info.security.read` scope (Enterprise accounts only).