### PR TITLE
fix: limit loader batch size for tap-hubspot to reduce memory usage (NEKT-3583)

### DIFF
--- a/nekt.config.json
+++ b/nekt.config.json
@@ -290,6 +290,12 @@
             "el_type": "extractor",
             "description": "When enabled, the 'properties' column is emitted as a JSON string instead of a structured object. Use this to work around destination limits on the number of nested fields (e.g. BigQuery's 10,000 field limit).",
             "advanced_settings": true
+          },
+          "max_size": {
+            "type": "integer",
+            "hidden": true,
+            "default": 1000,
+            "el_type": "loader"
           }
         }
       }


### PR DESCRIPTION
## Summary
- Some tap-hubspot sources require up to 60GB of Python execution memory, mainly due to the `emails` stream and large loader batches.
- The `emails` stream fetches all CRM properties for each record, including potentially large fields such as `hs_email_html`, `hs_email_text`, and `hs_body_preview`.
- The loader (target-bigquery-internal) currently buffers up to `max_size=250000` records per batch before flushing.
- This adds a hidden `max_size` config (`el_type: loader`, `default: 1000`) to `nekt.config.json`, following the same pattern already used by tap-postgres, tap-mongodb, tap-aws-s3, tap-clickhouse, tap-files, tap-parquet, tap-s3-parquet, tap-sap-sql-anywhere and tap-snowflake. This lets the platform apply a smaller loader batch size for hubspot pipelines specifically, without changing the global default for target-bigquery-internal.

## Test plan
- [ ] Verify `nekt.config.json` is valid JSON
- [ ] Verify generated `meltano.yml` applies `max_size: 1000` to the loader config for tap-hubspot pipelines